### PR TITLE
fix tabs in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 # that require ./configure && make.  You really
 # should use the build.sh script directly.
 
-all:    src/host/wxui/lisaem_wx.cpp
-        pwd
-        /bin/ls -l
-	./build.sh build 
+all:	src/host/wxui/lisaem_wx.cpp
+	pwd
+	/bin/ls -l
+	./build.sh build
 
 build:   src/host/wxui/lisaem_wx.cpp
-	./build.sh build 
+	./build.sh build
 
 clean:   src/host/wxui/lisaem_wx.cpp
 	./build.sh clean


### PR DESCRIPTION
To prevent current error:

Makefile:6: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.